### PR TITLE
Given the SessionKeeper a default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ package-lock.json
 wordcloud/data/
 
 .idea/
+
+# Toy data
+toywhipserer data

--- a/SessionKeeper.js
+++ b/SessionKeeper.js
@@ -33,7 +33,7 @@ function UserProfile(props) {
     profile['ownerID'] = null;
     profile['info'] = "[Info not set]";
     profile['kinks'] = "[Kinks not set]";
-    profile['toy mode'] = null;
+    profile['toy mode'] = 'alpha';
 	profile['beta access list'] = [];
     profile['can safeword'] = true;
     profile['sync level'] = 0;


### PR DESCRIPTION
The bot was crashing because a new user has no predefined toy type and couldn't load the brain data.